### PR TITLE
Add editor's route guard

### DIFF
--- a/src/pages/GraphicEditor/GraphicEditor.tsx
+++ b/src/pages/GraphicEditor/GraphicEditor.tsx
@@ -4,17 +4,13 @@ import { RightSideBar } from '@components/RightSidebar';
 import { TopMenu } from '@components/TopMenu';
 import { Box } from '@mui/material';
 import type {RootState} from "@/store";
-import type {Project} from "@shared/types/project.ts";
 import {Navigate, useParams} from "react-router-dom";
 import {useSelector} from "react-redux";
+import {checkProjectExistence} from "@store/utils/projects.ts";
 
 export const GraphicEditor: React.FC = () => {
-	const selectProjectExists = (state: RootState, id: string) => {
-		return state.projects.projects.some((p: Project) => p.id === id);
-	}
-
 	const { id } = useParams<{ id: string }>();
-	const exists: boolean = useSelector((state: RootState) => selectProjectExists(state, id ?? ''));
+	const exists: boolean = useSelector((state: RootState) => checkProjectExistence(state.projects, id ?? ''));
 
 	if (!exists) {
 		return <Navigate to="/404" replace />;

--- a/src/shared/types/projectsSliceState.ts
+++ b/src/shared/types/projectsSliceState.ts
@@ -1,0 +1,8 @@
+import type { History, Layer, Project } from '@shared/types/project.ts';
+
+export interface ProjectsSliceState {
+	projects: Project[];
+	history: Record<Project['id'], History[]>;
+	layers: Record<Project['id'], Layer[]>;
+	activeLayer: Layer | null;
+}

--- a/src/store/slices/projectsSlice.ts
+++ b/src/store/slices/projectsSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 import { generateId } from '@shared/helpers';
-import type { History, Layer, Project } from '@shared/types/project';
+import type { ProjectsSliceState } from '@shared/types/projectsSliceState';
 import type {
 	CreateLayerParams,
 	CreateProjectParams,
@@ -10,19 +10,9 @@ import type {
 	UpdateLayerParams,
 	UpdateProjectParams,
 } from './projectSliceTypes';
+import { checkProjectExistence} from '@store/utils/projects';
 
-interface State {
-	projects: Project[];
-	history: Record<Project['id'], History[]>;
-	layers: Record<Project['id'], Layer[]>;
-	activeLayer: Layer | null;
-}
-
-const checkProjectExistence = (state: State, projectId: Project['id']) => {
-	return state.projects.some(item => item.id === projectId);
-};
-
-const initialState: State = {
+const initialState: ProjectsSliceState = {
 	projects: [],
 	history: {},
 	layers: {},

--- a/src/store/utils/projects.ts
+++ b/src/store/utils/projects.ts
@@ -1,0 +1,6 @@
+import type { Project } from '@shared/types/project';
+import type { ProjectsSliceState } from '@shared/types/projectsSliceState';
+
+export const checkProjectExistence = (state: ProjectsSliceState, projectId: Project['id']) => {
+	return state.projects.some(item => item.id === projectId);
+};


### PR DESCRIPTION
Redirect to  /404 when a "projects/:id" isn’t found