### PR TITLE
feat(#178): keyboard shortcuts

### DIFF
--- a/src/components/LeftSidebar/components/ToolsGroup/ToolsGroup.tsx
+++ b/src/components/LeftSidebar/components/ToolsGroup/ToolsGroup.tsx
@@ -2,7 +2,7 @@ import { Box, Button } from '@mui/material';
 import type { RootState } from '@store/index';
 import { ACTIONS, setTool } from '@store/slices/toolsSlice';
 import { BrushIcon, CircleIcon, EraserIcon, MinusIcon, NavigationIcon, SquareIcon, TypeIcon } from 'lucide-react';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 const TOOLS = [
@@ -14,6 +14,16 @@ const TOOLS = [
 	{ id: ACTIONS.CIRCLE, icon: <CircleIcon size={16} color={'var(--color)'} />, label: 'Круг' },
 	{ id: ACTIONS.LINE, icon: <MinusIcon size={16} color={'var(--color)'} />, label: 'Линия' },
 ];
+
+const KEY_TO_TOOL: Record<string, ACTIONS> = {
+	'1': ACTIONS.SELECT,
+	'2': ACTIONS.BRUSH,
+	'3': ACTIONS.ERASER,
+	'4': ACTIONS.TEXT,
+	'5': ACTIONS.RECTANGLE,
+	'6': ACTIONS.CIRCLE,
+	'7': ACTIONS.LINE,
+};
 
 export const ToolsGroup: React.FC = () => {
 	const { tool } = useSelector((state: RootState) => state.tools);
@@ -29,13 +39,44 @@ export const ToolsGroup: React.FC = () => {
 		[dispatch],
 	);
 
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			const target = e.target as HTMLElement;
+
+			if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+				return;
+			}
+
+			let digit: string | null = null;
+
+			if (e.code?.startsWith('Digit')) {
+				digit = e.code.replace('Digit', '');
+			} else if (e.code?.startsWith('Numpad')) {
+				digit = e.code.replace('Numpad', '');
+			}
+
+			if (digit && digit >= '1' && digit <= '7') {
+				e.preventDefault();
+
+				const toolId = KEY_TO_TOOL[digit];
+
+				if (toolId) {
+					dispatch(setTool(toolId));
+				}
+			}
+		};
+
+		window.addEventListener('keydown', handleKeyDown);
+		return () => window.removeEventListener('keydown', handleKeyDown);
+	}, [dispatch]);
+
 	return (
 		<Box>
-			{TOOLS.map(tool => (
+			{TOOLS.map((tool, i) => (
 				<Button
 					key={tool.id}
 					variant='graphic-tools'
-					title={tool.label}
+					title={`${tool.label} (${i + 1})`}
 					onClick={() => handleToolClick(tool.id)}
 					sx={{
 						backgroundColor: isToolActive(tool.id) ? 'var(--color-primary)' : 'transparent',

--- a/src/components/LeftSidebar/components/ToolsHistoryGroup/ToolsHistoryGroup.tsx
+++ b/src/components/LeftSidebar/components/ToolsHistoryGroup/ToolsHistoryGroup.tsx
@@ -3,17 +3,18 @@ import type { RootState } from '@store/index';
 import { isRedoActiveSelector, isUndoActiveSelector, redoHistory, undoHistory } from '@store/slices/projectsSlice';
 import { ACTIONS } from '@store/slices/toolsSlice';
 import { Redo2Icon, Undo2Icon } from 'lucide-react';
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 
 const HISTORY_TOOLS = [
 	{
 		id: ACTIONS.UNDO,
-		label: 'Отменить',
+		label: 'Отменить (Ctrl+Z)',
 	},
 	{
 		id: ACTIONS.REDO,
-		label: 'Вернуть',
+		label: 'Вернуть (Ctrl+Shift+Z)',
 	},
 ];
 
@@ -22,6 +23,40 @@ export const ToolsHistoryGroup: React.FC = () => {
 	const { id: projectId = '' } = useParams();
 	const isUndoActive = useSelector((state: RootState) => isUndoActiveSelector(state, projectId));
 	const isRedoActive = useSelector((state: RootState) => isRedoActiveSelector(state, projectId));
+
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			const target = e.target as HTMLElement;
+			if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') {
+				return;
+			}
+
+			if (e.ctrlKey && !e.shiftKey && !e.altKey && e.code === 'KeyZ') {
+				e.preventDefault();
+				if (!isUndoActive) return;
+	
+				dispatch(
+					undoHistory({
+						projectId,
+					}),
+				);
+			}
+
+			if (e.ctrlKey && e.shiftKey && !e.altKey && e.code === 'KeyZ') {
+				e.preventDefault();
+				if (!isRedoActive) return;
+
+				dispatch(
+					redoHistory({
+						projectId,
+					}),
+				);
+			}
+		};
+
+		window.addEventListener('keydown', handleKeyDown);
+		return () => window.removeEventListener('keydown', handleKeyDown);
+	}, [dispatch, projectId, isUndoActive, isRedoActive]);
 
 	return (
 		<Box>

--- a/src/components/RightSidebar/components/LayersTab.tsx
+++ b/src/components/RightSidebar/components/LayersTab.tsx
@@ -14,7 +14,7 @@ import {
 } from '@store/slices/projectsSlice';
 import { HISTORY_ACTIONS } from '@store/slices/projectsSlice.enums';
 import { PlusIcon } from 'lucide-react';
-import { useState, type MouseEvent } from 'react';
+import { useEffect, useState, type MouseEvent } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import { SortableLayer } from '../components';
@@ -184,6 +184,83 @@ export const LayersTab = () => {
 			);
 		}
 	};
+
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			if (!activeLayer || !projectId || editingLayerId) return;
+
+			const target = e.target as HTMLElement;
+			if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) return;
+
+			const currentIndex = sortedLayers.findIndex(l => l.id === activeLayer.id);
+			if (currentIndex === -1) return;
+
+			if (!e.ctrlKey && !e.shiftKey && !e.altKey) {
+				if (e.key === 'ArrowUp' && currentIndex > 0) {
+					e.preventDefault();
+					dispatch(setActiveLayer({ projectId, id: sortedLayers[currentIndex - 1].id }));
+					return;
+				}
+
+				if (e.key === 'ArrowDown' && currentIndex < sortedLayers.length - 1) {
+					e.preventDefault();
+					dispatch(setActiveLayer({ projectId, id: sortedLayers[currentIndex + 1].id }));
+					return;
+				}
+			}
+
+			if (e.ctrlKey && !e.shiftKey && !e.altKey) {
+				let newIndex;
+				if (e.key === 'ArrowUp') {
+					newIndex = Math.max(0, currentIndex - 1);
+				} else if (e.key === 'ArrowDown') {
+					newIndex = Math.min(sortedLayers.length - 1, currentIndex + 1);
+				} else {
+					return;
+				}
+
+				e.preventDefault();
+				if (currentIndex === newIndex) return;
+
+				const newLayers = arrayMove(sortedLayers, currentIndex, newIndex);
+
+				newLayers.forEach((layer, index) => {
+					dispatch(
+						updateLayer({
+							projectId,
+							data: {
+								id: layer.id,
+								zIndex: newLayers.length - index,
+							},
+							canvasDataURL: activeLayer ? activeLayer.canvasDataURL : '',
+						}),
+					);
+				});
+				
+				dispatch(
+					setActiveLayer({
+						projectId,
+						id: activeLayer.id,
+					}),
+				);
+
+				if (activeLayer) {
+					dispatch(
+						addToHistory({
+							projectId,
+							activeLayer,
+							type: HISTORY_ACTIONS.LAYER_ORDER,
+							canvasDataURL: activeLayer.canvasDataURL,
+						}),
+					);
+				}
+			}
+		};
+
+		window.addEventListener('keydown', handleKeyDown);
+
+		return () => window.removeEventListener('keydown', handleKeyDown);
+	}, [activeLayer, sortedLayers, projectId, dispatch]);
 
 	return (
 		<Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', gap: '0.5rem' }}>

--- a/src/components/RightSidebar/components/SortableLayer.tsx
+++ b/src/components/RightSidebar/components/SortableLayer.tsx
@@ -63,7 +63,7 @@ export const SortableLayer: React.FC<SortableLayerProps> = ({
 					}}
 					{...attributes}
 					{...listeners}
-					onClick={e => e.stopPropagation()}>
+					onClick={e => e.stopPropagation()} title='Переместить (Ctrl+↑/↓)'>
 					<GripVertical size={16} />
 				</IconButton>
 

--- a/src/components/TopMenu/TopMenu.tsx
+++ b/src/components/TopMenu/TopMenu.tsx
@@ -10,6 +10,7 @@ import { BadgeCheckIcon, House } from 'lucide-react';
 import { useCallback, useEffect, useState, type MouseEvent } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
+import { HelpModal } from './components';
 
 export const TopMenu: React.FC = () => {
 	const navigate = useNavigate();
@@ -33,6 +34,7 @@ export const TopMenu: React.FC = () => {
 
 	const [saveStatus, setSaveStatus] = useState<'idle' | 'saved'>('idle');
 	const [fileAnchorEl, setFileAnchorEl] = useState<null | HTMLElement>(null);
+	const [isHelpModalOpen, setIsHelpModalOpen] = useState(false);
 	const fileMenuOpen = Boolean(fileAnchorEl);
 
 	const handleFileMenuClick = (event: MouseEvent<HTMLButtonElement>) => {
@@ -59,6 +61,11 @@ export const TopMenu: React.FC = () => {
 		handleFileMenuClose();
 	}, [exportPNG]);
 
+	const handleOpenHelpModal = () => {
+		setIsHelpModalOpen(true);
+		handleFileMenuClose();
+	};
+
 	useEffect(() => {
 		if (lastPreviewSavedAt) {
 			setSaveStatus('saved');
@@ -81,7 +88,7 @@ export const TopMenu: React.FC = () => {
 
 			if (e.code === 'F1') {
 				e.preventDefault();
-				console.log('F1');
+				setIsHelpModalOpen(true);
 				return;
 			}
 
@@ -213,7 +220,9 @@ export const TopMenu: React.FC = () => {
 				<MenuItem onClick={handleNewProject}>Новый проект (Ctrl+Alt+N)</MenuItem>
 				<MenuItem onClick={handleSave}>Сохранить (Ctrl+S)</MenuItem>
 				<MenuItem onClick={handleExportPng}>Экспортировать в png (Ctrl+E)</MenuItem>
+				<MenuItem onClick={handleOpenHelpModal}>Горячие клавиши (F1)</MenuItem>
 			</Menu>
+			<HelpModal open={isHelpModalOpen} onClose={() => setIsHelpModalOpen(false)} />
 		</>
 	);
 };

--- a/src/components/TopMenu/TopMenu.tsx
+++ b/src/components/TopMenu/TopMenu.tsx
@@ -7,7 +7,7 @@ import { useSaveProjectPreview } from '@shared/hooks/useSavePreview.tsx';
 import { type RootState } from '@store/index';
 import { toggleCreateProjectModal } from '@store/slices/modalsSlice.ts';
 import { BadgeCheckIcon, House } from 'lucide-react';
-import { useEffect, useState, type MouseEvent } from 'react';
+import { useCallback, useEffect, useState, type MouseEvent } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 
@@ -43,21 +43,21 @@ export const TopMenu: React.FC = () => {
 		setFileAnchorEl(null);
 	};
 
-	const handleNewProject = () => {
+	const handleNewProject = useCallback(() => {
 		dispatch(toggleCreateProjectModal());
 		handleFileMenuClose();
 		saveProjectPreview();
-	};
+	}, [dispatch, saveProjectPreview]);
 
-	const handleSave = () => {
+	const handleSave = useCallback(() => {
 		saveProjectPreview(true);
 		handleFileMenuClose();
-	};
+	}, [saveProjectPreview]);
 
-	const handleExportPng = () => {
+	const handleExportPng = useCallback(() => {
 		exportPNG();
 		handleFileMenuClose();
-	};
+	}, [exportPNG]);
 
 	useEffect(() => {
 		if (lastPreviewSavedAt) {
@@ -70,6 +70,48 @@ export const TopMenu: React.FC = () => {
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [lastPreviewSavedAt, lastSaveWasManual]);
+
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			const target = e.target as HTMLElement;
+
+			if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable) {
+				return;
+			}
+
+			if (e.code === 'F1') {
+				e.preventDefault();
+				console.log('F1');
+				return;
+			}
+
+			if (e.ctrlKey && !e.shiftKey && !e.altKey) {
+				switch (e.code) {
+					case 'KeyS':
+						e.preventDefault();
+						handleSave();
+						return;
+
+					case 'KeyE':
+						e.preventDefault();
+						handleExportPng();
+						return;
+
+					default:
+						break;
+				}
+			}
+
+			if (e.ctrlKey && e.altKey && !e.shiftKey && e.code === 'KeyN') {
+				e.preventDefault();
+				handleNewProject();
+				return;
+			}
+		};
+
+		window.addEventListener('keydown', handleKeyDown);
+		return () => window.removeEventListener('keydown', handleKeyDown);
+	}, [handleSave, handleExportPng, handleNewProject]);
 
 	return (
 		<>
@@ -168,9 +210,9 @@ export const TopMenu: React.FC = () => {
 						padding: 0,
 					},
 				}}>
-				<MenuItem onClick={handleNewProject}>Новый проект</MenuItem>
-				<MenuItem onClick={handleSave}>Сохранить</MenuItem>
-				<MenuItem onClick={handleExportPng}>Экспортировать в png</MenuItem>
+				<MenuItem onClick={handleNewProject}>Новый проект (Ctrl+Alt+N)</MenuItem>
+				<MenuItem onClick={handleSave}>Сохранить (Ctrl+S)</MenuItem>
+				<MenuItem onClick={handleExportPng}>Экспортировать в png (Ctrl+E)</MenuItem>
 			</Menu>
 		</>
 	);

--- a/src/components/TopMenu/components/HelpModal.tsx
+++ b/src/components/TopMenu/components/HelpModal.tsx
@@ -1,0 +1,75 @@
+import { Box, Button, DialogActions, Modal, Typography } from '@mui/material';
+
+const style = {
+	position: 'absolute',
+	top: '50%',
+	left: '50%',
+	transform: 'translate(-50%, -50%)',
+	width: 520,
+	bgcolor: 'var(--main-bg)',
+	color: 'var(--color)',
+	border: '2px solid var(--header-modal-border-color)',
+	outline: 'none',
+	borderRadius: 1.2,
+	p: 2.1,
+};
+
+interface HelpModalProps {
+	open: boolean;
+	onClose: () => void;
+}
+
+export const HelpModal: React.FC<HelpModalProps> = ({ open, onClose }) => {
+	return (
+		<Modal
+			open={open}
+			onClose={onClose}
+			aria-labelledby='hotkeys-modal-title'
+			aria-describedby='hotkeys-modal-description'
+		>
+			<Box sx={style}>
+				<Typography
+					id='hotkeys-modal-title'
+					component='h2'
+					sx={{ fontSize: '1.2rem', fontWeight: 600 }}
+				>
+					Горячие клавиши:
+				</Typography>
+
+				<Box
+					id='hotkeys-modal-description'
+					sx={{ mt: 1.5, color: 'var(--color-dark)', fontSize: '0.95rem' }}
+				>
+					<Typography>(1-7) — Выбор инструмента</Typography>
+					<Typography>(Ctrl + S) — Сохранить проект</Typography>
+					<Typography>(Ctrl + E) — Экспорт в PNG</Typography>
+					<Typography>(Ctrl + Alt + N) — Создать новый проект</Typography>
+					<Typography>(Ctrl + Z) — Отменить действие</Typography>
+					<Typography>(Ctrl + Shift + Z) — Вернуть действие</Typography>
+					<Typography>(+) — Увеличить полотно</Typography>
+					<Typography>(-) — Уменьшить полотно</Typography>
+					<Typography>(Ctrl+↑) — Переместить выделенный слой вверх</Typography>
+					<Typography>(Ctrl+↓) — Переместить выделенный слой вниз</Typography>
+					<Typography>(↑) — Переключиться на слой выше</Typography>
+					<Typography>(↓) — Переключиться на слой ниже</Typography>
+					<Typography>(F1) — Открыть список горячих клавиш</Typography>
+				</Box>
+
+				<DialogActions sx={{ mt: 2 }}>
+					<Button
+						variant='outlined'
+						onClick={onClose}
+						sx={{
+							textTransform: 'none',
+							fontWeight: 600,
+							color: 'var(--color)',
+							borderColor: 'var(--header-modal-border-color)',
+						}}
+					>
+						Закрыть
+					</Button>
+				</DialogActions>
+			</Box>
+		</Modal>
+	);
+};

--- a/src/components/TopMenu/components/index.ts
+++ b/src/components/TopMenu/components/index.ts
@@ -1,0 +1,1 @@
+export * from './HelpModal';

--- a/src/components/ZoomBar/ZoomBar.tsx
+++ b/src/components/ZoomBar/ZoomBar.tsx
@@ -80,7 +80,7 @@ export const ZoomBar = () => {
 			</Box>
 
 			<Box sx={{ display: 'flex', alignItems: 'center', gap: 2, width: '35%' }}>
-				<IconButton onClick={handleMinus} size='small' sx={{ color: 'var(--color)' }}>
+				<IconButton onClick={handleMinus} size='small' sx={{ color: 'var(--color)' }} title='Уменьшить (-)'>
 					<ZoomOut size={18} />
 				</IconButton>
 
@@ -96,7 +96,7 @@ export const ZoomBar = () => {
 					}}
 				/>
 
-				<IconButton onClick={handlePlus} size='small' sx={{ color: 'var(--color)' }}>
+				<IconButton onClick={handlePlus} size='small' sx={{ color: 'var(--color)' }} title='Увеличить (+)'>
 					<ZoomIn size={18} />
 				</IconButton>
 			</Box>

--- a/src/components/ZoomBar/ZoomBar.tsx
+++ b/src/components/ZoomBar/ZoomBar.tsx
@@ -2,6 +2,7 @@ import { Box, Button, IconButton, Paper, Slider, Typography } from '@mui/materia
 import type { RootState } from '@store/index';
 import { setZoom } from '@store/slices/projectsSlice';
 import { RefreshCcw, ZoomIn, ZoomOut } from 'lucide-react';
+import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 
 export const ZoomBar = () => {
@@ -15,6 +16,34 @@ export const ZoomBar = () => {
 	const handleMinus = () => dispatch(setZoom(Math.max(0.1, zoom - 0.1)));
 	const handlePlus = () => dispatch(setZoom(Math.min(3, zoom + 0.1)));
 	const handleReset = () => dispatch(setZoom(1));
+
+	useEffect(() => {
+		const handleKeyDown = (e: KeyboardEvent) => {
+			const target = e.target as HTMLElement;
+			const isSliderElement = target.closest('[role="slider"], .MuiSlider-root');
+
+			if (
+				!isSliderElement &&
+				(target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)
+			) {
+				return;
+			}
+
+			if (e.key === '+' || e.key === '=') {
+				e.preventDefault();
+				handlePlus();
+			}
+			if (e.key === '-' || e.key === '_') {
+				e.preventDefault();
+				handleMinus();
+			}
+		};
+
+		window.addEventListener('keydown', handleKeyDown);
+
+		return () => window.removeEventListener('keydown', handleKeyDown);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [zoom]);
 
 	return (
 		<Paper

--- a/src/store/slices/projectsSlice.ts
+++ b/src/store/slices/projectsSlice.ts
@@ -167,24 +167,24 @@ const projectsSlice = createSlice({
 			 * Тут делаем изменяемый слой активным
 			 * в случае, если он неактивен
 			 */
-			if (state.activeLayer?.id !== layer.id) {
-				state.activeLayer = layer;
+			// if (state.activeLayer?.id !== layer.id) {
+			// 	state.activeLayer = layer;
 
-				/**
-				 * Тут действия с историей.
-				 * Увеличиваем указатель на шаг
-				 */
-				const newPointer = ++state.history[projectId].pointer;
-				// и добавляем новый элемент в историю
-				state.history[projectId].history[newPointer] = {
-					layers: [...state.layers[projectId]],
-					objects: [...state.canvasObjects],
-					type: HISTORY_ACTIONS.LAYER_ACTIVE,
-					id: newPointer,
-					date: new Date().getTime(),
-					activeLayer: layer,
-				};
-			}
+			// 	/**
+			// 	 * Тут действия с историей.
+			// 	 * Увеличиваем указатель на шаг
+			// 	 */
+			// 	const newPointer = ++state.history[projectId].pointer;
+			// 	// и добавляем новый элемент в историю
+			// 	state.history[projectId].history[newPointer] = {
+			// 		layers: [...state.layers[projectId]],
+			// 		objects: [...state.canvasObjects],
+			// 		type: HISTORY_ACTIONS.LAYER_ACTIVE,
+			// 		id: newPointer,
+			// 		date: new Date().getTime(),
+			// 		activeLayer: layer,
+			// 	};
+			// }
 			// Устанавливаем активность истории для перерисовки
 			state.history[projectId].active = true;
 		},
@@ -259,7 +259,13 @@ const projectsSlice = createSlice({
 			const layerIndex = state.layers?.[payload.projectId]?.findIndex(item => item.id === payload.id);
 			if (layerIndex === -1 || layerIndex === undefined) throw new Error(`Layer with ID ${payload.id} not found`);
 
-			state.activeLayer = state.layers[payload.projectId][layerIndex];
+			const nextActiveLayer = state.layers[payload.projectId][layerIndex];
+
+			if (state.activeLayer?.id === nextActiveLayer.id) {
+				return;
+			}
+
+			state.activeLayer = nextActiveLayer;
 
 			/**
 			 * Тут действия с историей.


### PR DESCRIPTION
closes #178 
Добавил все планируемые горячие клавиши и модальное окно с описанием этих клавиш:
(F1) — Открыть список горячих клавиш
(1-7) — Выбор инструмента
(Ctrl + S) — Сохранить проект
(Ctrl + E) — Экспорт в PNG
(Ctrl + Alt + N) — Создать новый проект
(Ctrl + Z) — Отменить действие
(Ctrl + Shift + Z) — Вернуть действие
(+) — Увеличить полотно
(-) — Уменьшить полотно
(Ctrl+↑) — Переместить выделенный слой вверх
(Ctrl+↓) — Переместить выделенный слой вниз
(↑) — Переключиться на слой выше
(↓) — Переключиться на слой ниже