### PR TITLE
fix: loading on save project

### DIFF
--- a/src/components/TopMenu/TopMenu.tsx
+++ b/src/components/TopMenu/TopMenu.tsx
@@ -6,6 +6,7 @@ import { useProjectNameEditing } from '@shared/hooks/useProjectNameEditing';
 import { useSaveProjectPreview } from '@shared/hooks/useSavePreview.tsx';
 import { type RootState } from '@store/index';
 import { toggleCreateProjectModal } from '@store/slices/modalsSlice.ts';
+import { resetPreviewSave } from '@store/slices/projectsSlice';
 import { BadgeCheckIcon, House } from 'lucide-react';
 import { useEffect, useState, type MouseEvent } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
@@ -31,6 +32,7 @@ export const TopMenu: React.FC = () => {
 		projects,
 	});
 
+	const [isInitialMount, setIsInitialMount] = useState<boolean>(true);
 	const [saveStatus, setSaveStatus] = useState<'idle' | 'saved'>('idle');
 	const [fileAnchorEl, setFileAnchorEl] = useState<null | HTMLElement>(null);
 	const fileMenuOpen = Boolean(fileAnchorEl);
@@ -60,16 +62,23 @@ export const TopMenu: React.FC = () => {
 	};
 
 	useEffect(() => {
-		if (lastPreviewSavedAt) {
-			setSaveStatus('saved');
-
-			const duration = lastSaveWasManual ? 1500 : 1000;
-			const timer = setTimeout(() => setSaveStatus('idle'), duration);
-
-			return () => clearTimeout(timer);
+		if (isInitialMount) {
+			dispatch(resetPreviewSave());
+			setIsInitialMount(false);
 		}
+	}, [dispatch, isInitialMount]);
+
+	useEffect(() => {
+		if (isInitialMount || !lastPreviewSavedAt) return;
+
+		setSaveStatus('saved');
+
+		const duration = lastSaveWasManual ? 1500 : 1000;
+		const timer = setTimeout(() => setSaveStatus('idle'), duration);
+
+		return () => clearTimeout(timer);
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [lastPreviewSavedAt, lastSaveWasManual]);
+	}, [lastPreviewSavedAt, lastSaveWasManual, isInitialMount]);
 
 	return (
 		<>

--- a/src/store/slices/projectsSlice.ts
+++ b/src/store/slices/projectsSlice.ts
@@ -556,6 +556,11 @@ const projectsSlice = createSlice({
 			state.save.lastSaveWasManual = manual;
 		},
 
+		resetPreviewSave: state => {
+			state.save.lastPreviewSavedAt = null;
+			state.save.lastSaveWasManual = false;
+		},
+
 		addCanvasObject: (state, action: PayloadAction<Drawable>) => {
 			state.canvasObjects.push(action.payload);
 		},
@@ -649,6 +654,7 @@ export const {
 	updateCanvasObject,
 	removeCanvasObject,
 	setPreviewSaved,
+	resetPreviewSave,
 } = projectsSlice.actions;
 
 export default projectsSlice.reducer;


### PR DESCRIPTION
Исправлен баг связанный с текстом "Сохранено", отображающийся после сохранения в одном проекта и при переходе на другой проект в самом начале